### PR TITLE
change default options for rsync calls

### DIFF
--- a/assets/in
+++ b/assets/in
@@ -67,7 +67,7 @@ if [ -z "$VERSION" ]; then
   exit 1
 else
   if (ssh -t -i ~/.ssh/server_key -p $PORT $USER@$SERVER '[ -d $SRC_DIR ]' ); then
-    RSYNC_CMD="rsync -Pav -e 'ssh -i ~/.ssh/server_key -p $PORT' $USER@$SERVER:$SRC_DIR/* $DEST_DIR"
+    RSYNC_CMD="rsync -a -e 'ssh -i ~/.ssh/server_key -p $PORT' $USER@$SERVER:$SRC_DIR/* $DEST_DIR"
     echo $RSYNC_CMD  1>&2
     eval $RSYNC_CMD  1>&2
     if [ $? -eq 0 ]; then

--- a/assets/out
+++ b/assets/out
@@ -34,7 +34,7 @@ BUILD_DEFINED_VERSIONING=$?
 
 if [ -z "$RSYNC_OPTS_ARR" ]
 then
-    RSYNC_OPTS="-Pav"
+    RSYNC_OPTS="-a"
 else
     RSYNC_OPTS=$(jq -r 'join(" ")' <<< $RSYNC_OPTS_ARR)
 fi


### PR DESCRIPTION
`-Pav` floods our logs, slows down the concourse web UI and makes me want to do terrible things to myself. `-a`!