### PR TITLE
enable build_defined_versioning as input resource

### DIFF
--- a/assets/in
+++ b/assets/in
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
 DEST_DIR=$1
-echo $SRC_DIR 1>&2
-echo $BUILD_ID 1>&2
-echo $BUILD_NAME 1>&2
-echo $BUILD_JOB_NAME 1>&2
-echo $BUILD_PIPELINE_NAME 1>&2
-echo $ATC_EXTERNAL_URL 1>&2
+echo "---RSYNC IN---"                           1>&2
+echo "SRC_DIR=$SRC_DIR"                         1>&2
+echo "BUILD_ID=$BUILD_ID"                       1>&2
+echo "BUILD_NAME=$BUILD_NAME"                   1>&2
+echo "BUILD_JOB_NAME=$BUILD_JOB_NAME"           1>&2
+echo "BUILD_PIPELINE_NAME=$BUILD_PIPELINE_NAME" 1>&2
+echo "ATC_EXTERNAL_URL=$ATC_EXTERNAL_URL"       1>&2
 
 PLATFORM=`uname`
 MD5_TOOL="md5sum"
@@ -37,12 +38,24 @@ if [ -z "$PORT" ]; then
     PORT=22
 fi
 
-echo $SCRIPT_INPUT 1>&2
-echo $SERVER    1>&2
-echo $PORT      1>&2
-echo $BASE_DIR  1>&2
-echo $USER      1>&2
-echo $VERSION   1>&2
+### console output
+echo "SCRIPT_INPUT=$SCRIPT_INPUT"                         1>&2
+echo "SERVER=$SERVER"                                     1>&2
+echo "PORT=$PORT"                                         1>&2
+echo "BASE_DIR=$BASE_DIR"                                 1>&2
+echo "USER=$USER"                                         1>&2
+echo "VERSION=$VERSION"                                   1>&2
+if [ $DISABLE_VERSION_PATH -eq 0 ]; then
+    echo "DISABLE_VERSION_PATH=ON" 1>&2
+else
+    echo "DISABLE_VERSION_PATH=OFF" 1>&2
+fi
+if [ $BUILD_DEFINED_VERSIONING -eq 0 ]; then
+    echo "BUILD_DEFINED_VERSIONING=ON" 1>&2
+else
+    echo "BUILD_DEFINED_VERSIONING=OFF" 1>&2
+fi
+######
 
 mkdir -p ~/.ssh
 (jq -r '.source.private_key // empty' < $SCRIPT_INPUT) > ~/.ssh/server_key
@@ -53,7 +66,7 @@ eval $(ssh-agent) 1>&2 >/dev/null
 SSH_ASKPASS=/opt/resource/askpass.sh DISPLAY= ssh-add ~/.ssh/server_key 1>&2 >/dev/null
 
 if [ $BUILD_DEFINED_VERSIONING -eq 0 ]; then
-    SRC_DIR=$BASE_DIR/"$BUILD_PIPELINE_NAME-$BUILD_NAME"
+    SRC_DIR=$BASE_DIR/$VERSION
 elif [ $DISABLE_VERSION_PATH -eq 0 ]; then
     SRC_DIR=$BASE_DIR
 else
@@ -72,6 +85,7 @@ else
     eval $RSYNC_CMD  1>&2
     if [ $? -eq 0 ]; then
         OUTPUT_STRING="{ \"version\": { \"ref\": \"$MD5_STRING\"} }"
+        echo "OUTPUT_STRING=$OUTPUT_STRING" 1>&2
         echo $OUTPUT_STRING
         exit 0
     else

--- a/assets/out
+++ b/assets/out
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
 SRC_DIR=$1
-echo $SRC_DIR 1>&2
-echo $BUILD_ID 1>&2
-echo $BUILD_NAME 1>&2
-echo $BUILD_JOB_NAME 1>&2
-echo $BUILD_PIPELINE_NAME 1>&2
-echo $ATC_EXTERNAL_URL 1>&2
+echo "---RSYNC OUT---"                          1>&2
+echo "SRC_DIR=$SRC_DIR"                         1>&2
+echo "BUILD_ID=$BUILD_ID"                       1>&2
+echo "BUILD_NAME=$BUILD_NAME"                   1>&2
+echo "BUILD_JOB_NAME=$BUILD_JOB_NAME"           1>&2
+echo "BUILD_PIPELINE_NAME=$BUILD_PIPELINE_NAME" 1>&2
+echo "ATC_EXTERNAL_URL=$ATC_EXTERNAL_URL"       1>&2
 
 PLATFORM=`uname`
 MD5_TOOL="md5sum"
@@ -45,14 +46,24 @@ if [ -z "$PORT" ]; then
     PORT=22
 fi
 
-echo $SCRIPT_INPUT 1>&2
-echo $SERVERS      1>&2
-echo $PORT         1>&2
-echo $BASE_DIR     1>&2
-echo $USER         1>&2
-echo $SYNC_DIR     1>&2
-echo "DISABLE_VERSION_PATH=$DISABLE_VERSION_PATH" 1>&2
-echo "BUILD_DEFINED_VERSIONING=$BUILD_DEFINED_VERSIONING" 1>&2
+### console output
+echo "SCRIPT_INPUT=$SCRIPT_INPUT"                         1>&2
+echo "SERVERS=$SERVERS"                                   1>&2
+echo "PORT=$PORT"                                         1>&2
+echo "BASE_DIR=$BASE_DIR"                                 1>&2
+echo "USER=$USER"                                         1>&2
+echo "SYNC_DIR=$SYNC_DIR"                                 1>&2
+if [ $DISABLE_VERSION_PATH -eq 0 ]; then
+    echo "DISABLE_VERSION_PATH=ON" 1>&2
+else
+    echo "DISABLE_VERSION_PATH=OFF" 1>&2
+fi
+if [ $BUILD_DEFINED_VERSIONING -eq 0 ]; then
+    echo "BUILD_DEFINED_VERSIONING=ON" 1>&2
+else
+    echo "BUILD_DEFINED_VERSIONING=OFF" 1>&2
+fi
+######
 
 mkdir -p ~/.ssh
 (jq -r '.source.private_key // empty' < $SCRIPT_INPUT) > ~/.ssh/server_key
@@ -67,23 +78,24 @@ eval $(ssh-agent) 1>&2 2>/dev/null
 SSH_ASKPASS=/opt/resource/askpass.sh DISPLAY= ssh-add ~/.ssh/server_key 1>&2 2>/dev/null
 
 VERSION_STRING="$BUILD_PIPELINE_NAME-$BUILD_ID"
-echo $VERSION_STRING 1>&2
+echo "VERSION_STRING=$VERSION_STRING" 1>&2
 
 MD5_STRING=`echo $VERSION_STRING | $MD5_TOOL | cut -d ' ' -f 1 `
 if [ $? -eq 0 ]; then
-  echo $MD5_STRING 1>&2
   
   if [ $BUILD_DEFINED_VERSIONING -eq 0 ]; then
       MD5_PATH=""
+      MD5_STRING="$BUILD_PIPELINE_NAME"-"$BUILD_NAME"
   elif [ $DISABLE_VERSION_PATH -eq 0 ]; then
       MD5_PATH=""
   else
       MD5_PATH=$MD5_STRING
   fi
+  echo "MD5_STRING=$MD5_STRING" 1>&2
 
   # Create the new directory for this build
   DEST_DIR=$BASE_DIR/$MD5_PATH
-  echo $DEST_DIR 1>&2
+  echo "DEST_DIR=$DEST_DIR" 1>&2
  
   REPORTED_VERSION=0
   for SERVER in $SERVERS
@@ -94,13 +106,14 @@ if [ $? -eq 0 ]; then
       
       if [ $? -eq 0 ]; then
         RSYNC_CMD="rsync $RSYNC_OPTS -e 'ssh -i ~/.ssh/server_key -p $PORT'  $SRC_DIR/$SYNC_DIR/ $USER@$SERVER:$DEST_DIR"
-        echo $RSYNC_CMD 1>&2
+        echo "RSYNC_CMD=$RSYNC_CMD" 1>&2
 
         eval $RSYNC_CMD  1>&2
         if [ $? -eq 0 ]; then
             if [ $REPORTED_VERSION -eq 0 ]
             then
                 OUTPUT_STRING="{ \"version\": { \"ref\": \"$MD5_STRING\"} }"
+                echo "OUTPUT_STRING=$OUTPUT_STRING" 1>&2
                 echo $OUTPUT_STRING
                 REPORTED_VERSION=1
             fi


### PR DESCRIPTION
#### what ####
md5 hash was being set as the version ref for concourse cache, meaning input would look for that as the folder name

#### how ####
- output proper ref for concourse
- have input based on ref rather than current build environment
- make console printouts more readable

#### consider
- using build_defined_versioning makes output directories on the NAS human-readable
- however, if CI restarts from build 0, NAS needs to be flushed!