### PR TITLE
name version based on directory in sync_dir

### DIFF
--- a/assets/out
+++ b/assets/out
@@ -83,54 +83,53 @@ echo "VERSION_STRING=$VERSION_STRING" 1>&2
 MD5_STRING=`echo $VERSION_STRING | $MD5_TOOL | cut -d ' ' -f 1 `
 if [ $? -eq 0 ]; then
   
-  if [ $BUILD_DEFINED_VERSIONING -eq 0 ]; then
-      MD5_PATH=""
-      if [ -e "$SRC_DIR"/software/.git/id ]; then
-          MD5_STRING="$BUILD_PIPELINE_NAME"-"$(cat $SRC_DIR/software/.git/id)"-build-"$BUILD_NAME"
-      else
-          MD5_STRING="$BUILD_PIPELINE_NAME"-"$BUILD_NAME"
-      fi
-  elif [ $DISABLE_VERSION_PATH -eq 0 ]; then
-      MD5_PATH=""
-  else
-      MD5_PATH=$MD5_STRING
-  fi
-  echo "MD5_STRING=$MD5_STRING" 1>&2
+    if [ $BUILD_DEFINED_VERSIONING -eq 0 ]; then
+        MD5_PATH=""
+        for dir in $SRC_DIR/$SYNC_DIR/*
+        do
+            MD5_STRING=$(basename $dir)
+        done
+    elif [ $DISABLE_VERSION_PATH -eq 0 ]; then
+        MD5_PATH=""
+    else
+        MD5_PATH=$MD5_STRING
+    fi
+    echo "MD5_STRING=$MD5_STRING" 1>&2
 
-  # Create the new directory for this build
-  DEST_DIR=$BASE_DIR/$MD5_PATH
-  echo "DEST_DIR=$DEST_DIR" 1>&2
+    # Create the new directory for this build
+    DEST_DIR=$BASE_DIR/$MD5_PATH
+    echo "DEST_DIR=$DEST_DIR" 1>&2
  
-  REPORTED_VERSION=0
-  for SERVER in $SERVERS
-  do
-      CMD="ssh -i ~/.ssh/server_key -p $PORT $USER@$SERVER mkdir -p $DEST_DIR"
-      echo $CMD 1>&2
-      eval $CMD 1>&2
-      
-      if [ $? -eq 0 ]; then
-        RSYNC_CMD="rsync $RSYNC_OPTS -e 'ssh -i ~/.ssh/server_key -p $PORT'  $SRC_DIR/$SYNC_DIR/ $USER@$SERVER:$DEST_DIR"
-        echo "RSYNC_CMD=$RSYNC_CMD" 1>&2
-
-        eval $RSYNC_CMD  1>&2
+    REPORTED_VERSION=0
+    for SERVER in $SERVERS
+    do
+        CMD="ssh -i ~/.ssh/server_key -p $PORT $USER@$SERVER mkdir -p $DEST_DIR"
+        echo $CMD 1>&2
+        eval $CMD 1>&2
+        
         if [ $? -eq 0 ]; then
-            if [ $REPORTED_VERSION -eq 0 ]
-            then
-                OUTPUT_STRING="{ \"version\": { \"ref\": \"$MD5_STRING\"} }"
-                echo "OUTPUT_STRING=$OUTPUT_STRING" 1>&2
-                echo $OUTPUT_STRING
-                REPORTED_VERSION=1
-            fi
+          RSYNC_CMD="rsync $RSYNC_OPTS -e 'ssh -i ~/.ssh/server_key -p $PORT'  $SRC_DIR/$SYNC_DIR/ $USER@$SERVER:$DEST_DIR"
+          echo "RSYNC_CMD=$RSYNC_CMD" 1>&2
+
+          eval $RSYNC_CMD  1>&2
+          if [ $? -eq 0 ]; then
+              if [ $REPORTED_VERSION -eq 0 ]
+              then
+                  OUTPUT_STRING="{ \"version\": { \"ref\": \"$MD5_STRING\"} }"
+                  echo "OUTPUT_STRING=$OUTPUT_STRING" 1>&2
+                  echo $OUTPUT_STRING
+                  REPORTED_VERSION=1
+              fi
+          else
+            echo "Failed to rsync $SRC_DIR to $DEST_DIR" 1>&2
+            exit 1
+          fi
         else
-          echo "Failed to rsync $SRC_DIR to $DEST_DIR" 1>&2
+          echo "Failed to create destination $DEST_DIR" 1>&2
           exit 1
         fi
-      else
-        echo "Failed to create destination $DEST_DIR" 1>&2
-        exit 1
-      fi
-  done
+    done
 else
-  echo "Failed to create MD5 hash" 1>&2
-  exit 1
+    echo "Failed to create MD5 hash" 1>&2
+    exit 1
 fi


### PR DESCRIPTION
decouples the naming of versions from the build metadata
now when build_defined_versioning is enabled, the out resource looks in the sync_dir and uses the name of the directory contained as the version name